### PR TITLE
Update to be compatible with Wallee plugin version >= 3.1.3

### DIFF
--- a/includes/class-wc-wallee-subscription-gateway.php
+++ b/includes/class-wc-wallee-subscription-gateway.php
@@ -101,7 +101,7 @@ class WC_Wallee_Subscription_Gateway {
 			$token_space_id = get_post_meta( $order->get_id(), '_wallee_subscription_space_id', true );
 			$token_id = get_post_meta( $order->get_id(), '_wallee_subscription_token_id', true );
 
-			if ( empty( $token_space_id ) || get_option( WooCommerce_Wallee::CK_SPACE_ID ) != $token_space_id ) {
+			if ( empty( $token_space_id ) || get_option( WooCommerce_Wallee::WALLEE_CK_SPACE_ID ) != $token_space_id ) {
 				$order->update_status( 'failed', __( 'The token space and the configured space are not equal.', 'woo-wallee-subscription' ) );
 				return;
 			}
@@ -261,7 +261,7 @@ class WC_Wallee_Subscription_Gateway {
 		if ( $this->gateway->id === $payment_method_id ) {
 			if ( ! isset( $payment_meta['post_meta']['_wallee_subscription_space_id']['value'] ) || empty( $payment_meta['post_meta']['_wallee_subscription_space_id']['value'] ) ) {
 				throw new Exception( __( 'The wallee Space Id value is required.', 'woo-wallee-subscription' ) );
-			} elseif ( get_option( WooCommerce_Wallee::CK_SPACE_ID ) != $payment_meta['post_meta']['_wallee_subscription_space_id']['value'] ) {
+			} elseif ( get_option( WooCommerce_Wallee::WALLEE_CK_SPACE_ID ) != $payment_meta['post_meta']['_wallee_subscription_space_id']['value'] ) {
 				throw new Exception( __( 'The wallee Space Id needs to be in the same space as configured in the main configuration.', 'woo-wallee-subscription' ) );
 			}
 			if ( ! isset( $payment_meta['post_meta']['_wallee_subscription_token_id']['value'] ) || empty( $payment_meta['post_meta']['_wallee_subscription_token_id']['value'] ) ) {

--- a/includes/service/class-wc-wallee-subscription-service-transaction.php
+++ b/includes/service/class-wc-wallee-subscription-service-transaction.php
@@ -33,10 +33,10 @@ class WC_Wallee_Subscription_Service_Transaction extends WC_Wallee_Service_Trans
 	 * 	 If the transaction being created is not valid.
 	 */
 	public function create_transaction_by_renewal_order( WC_Order $order, $order_total, $token_id ) {
-		$space_id = get_option( WooCommerce_Wallee::CK_SPACE_ID );
+		$space_id = get_option( WooCommerce_Wallee::WALLEE_CK_SPACE_ID );
 		$create_transaction = new \Wallee\Sdk\Model\TransactionCreate();
 		$create_transaction->setCustomersPresence( \Wallee\Sdk\Model\CustomersPresence::VIRTUAL_PRESENT );
-		$space_view_id = get_option( WooCommerce_Wallee::CK_SPACE_VIEW_ID );
+		$space_view_id = get_option( WooCommerce_Wallee::WALLEE_CK_SPACE_VIEW_ID );
 		if ( is_numeric( $space_view_id ) ) {
 			$create_transaction->setSpaceViewId( $space_view_id );
 		}


### PR DESCRIPTION
Commit wallee-payment/woocommerce@96d14e3 breaks the current version of this plugin by changing the `CK_SPACE_ID` and `CK_SPACE_VIEW_ID` keys in the `WooCommerce_Wallee` to be prefixed by `WALLEE_`. This pull request fixes this, and intends to make this plugin compatible with the version 3.1.3 or newer of the Wallee plugin.